### PR TITLE
Better error handling.

### DIFF
--- a/autoload/crcs.vim
+++ b/autoload/crcs.vim
@@ -193,7 +193,10 @@ endfunction
 
 function! crcs#JumpToCallers()
   call crcs#Setup()
-  cexpr pyeval('GetCallers()')
+  let l:callers=pyeval('GetCallers()')
+  if l:callers != ''
+    cexpr l:callers
+  endif
 endfunction
 
 function! crcs#JumpToNextFile()
@@ -211,7 +214,10 @@ endfunction
 
 function! crcs#GoToRef(t)
   call crcs#Setup()
-  cexpr pyeval("GetReferences('" . a:t . "')")
+  let l:refs = pyeval("GetReferences('" . a:t . "')")
+  if length(l:refs) != 0
+    cexpr l:refs
+  endif
 endfunction
 
 function! crcs#ShowAnnotationsHere()
@@ -235,6 +241,6 @@ function! crcs#CloseCallgraphFold()
 endfunction
 
 function! crcs#PrepareForTesting()
-	call crcs#Setup()
+  call crcs#Setup()
   py PrepareForTesting()
 endfunction


### PR DESCRIPTION
Previously the vim-codesearch's vimscript code would invoke expressions
like "cexpr py SomePythonFunction()" where the resulting list should be
interpreted as a quickfix list. However if the resulting list was empty,
VIM displays a loud error message.

In order to suppress the no-op cases, the code now invokes Python
functions indirectly and only invokes cexpr with the resulting non-empty
list.

In addition, this change also adds better exception handling for all the
custom excepctions that are raised by the codesearch-py library. The
handlers then turn those exception messages into useful Vim error
messages.

Furthermore, invoking 'echoerr' from within Python code apparently
causes Neovim to add a stacktrace to the message. Neither this nor the
fact that the errors end up in the message log are necessary nor
desirable. So we now use a plain "echo" with an appropriate highlight
group to tone down the error messages.

All in all, this change should make vim-codesearch much more palatable
when things go wrong.