### PR TITLE
Travis CI: Add flake8 tests to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: generic
 
-# Ubuntu Trusty is required for getting Python3 PIP setup working without too
-# much pain. The Precise images don't have a python3-pip package.
-dist: trusty
-sudo: required
-
 before_install:
   - sudo apt-get update -q
   - sudo apt-get install -qq python python3 python-pip python-setuptools python3-setuptools python3-pip
@@ -14,5 +9,11 @@ before_install:
   - mkdir deps
   - cd deps && git clone --depth 1 -q https://github.com/google/vroom.git && cd vroom && python3 setup.py build && sudo python3 setup.py install && cd ../..
 
-script: ./run_tests.sh
+before_script:
+  - python2 -m pip install --user flake8
+  - python3 -m pip install --user flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
+script: ./run_tests.sh


### PR DESCRIPTION
This PR finds issues so it is __expected to fail__ until those issues are resolved.
* Where is [__CR_CS_PYTHON_ROOT__](https://github.com/chromium/vim-codesearch/search?q=CR_CS_PYTHON_ROOT&unscoped_q=CR_CS_PYTHON_ROOT) defined?
* The _builtin_ [__cmp()__](https://github.com/chromium/vim-codesearch/search?q=cmp&unscoped_q=cmp) was removed in Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/chromium/vim-codesearch on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./vimsupport.py:19:30: F821 undefined name 'CR_CS_PYTHON_ROOT'
sys.path.append(os.path.join(CR_CS_PYTHON_ROOT, 'third_party', 'codesearch-py'))
                             ^
./vimsupport.py:20:17: F821 undefined name 'CR_CS_PYTHON_ROOT'
sys.path.append(CR_CS_PYTHON_ROOT)
                ^
./vimsupport.py:67:12: F821 undefined name 'CR_CS_PYTHON_ROOT'
""".format(CR_CS_PYTHON_ROOT))
           ^
./render/render.py:296:14: F821 undefined name 'cmp'
      return cmp(r1[1].line_number, r2[1].line_number)
             ^
./render/render.py:297:12: F821 undefined name 'cmp'
    return cmp(r1[0].name, r2[0].name)
           ^
5     F821 undefined name 'cmp'
5
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree